### PR TITLE
Passing new references to next middleware

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,22 @@ middleware.run({ life: '41' }); // "no!"
 middleware.run({ life: '42' }); // "yes!"
 ```
 
+  Pass new references, make sure to pass on all arguments aswell an error argument:
+
+```js
+var ware = require('ware');
+var middleware = ware()
+  .use(function (arr, next) {
+    next(null, arr.map(function (a) { return a * a; }));
+  })
+  .use(function (arr, next) {
+    console.log(arr);
+    next();
+  });
+
+middleware.run([ 1, 2, 3 ]); // 1, 4, 9
+```
+
 ## API
 
 #### ware()

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,11 @@ Ware.prototype.run = function () {
     : [].slice.call(arguments);
 
   function next (err) {
+    if (arguments.length > 1) {
+      if (arguments.length != args.length + 1)
+        throw new TypeError("Wrong number of arguments. Expected " + args.length + 1 + " arguments.");
+      args = [].slice.call(arguments, 1);
+    }
     var fn = fns[i++];
     if (!fn) return callback && callback.apply(null, [err].concat(args));
 

--- a/test/index.js
+++ b/test/index.js
@@ -100,6 +100,27 @@ describe('ware', function () {
         });
     });
 
+    it('should allow middlewares to pass new references', function (done) {
+      var one = { test: "test1" },
+        two = { test: "test2" };
+
+      ware()
+        .use(function (a, b, next) {
+          next(null, a, { test : "test3" });
+        })
+        .use(function (a, b, next) {
+          a.test = "test4";
+          next();
+        })
+        .run(one, two, function (err, a, b) {
+          assert.strictEqual(a, one);
+          assert.notStrictEqual(b, two);
+          assert.equal(b.test, "test3");
+          assert.equal(a.test, "test4");
+          done();
+        });
+    });
+
     it('should not require a callback', function (done) {
       ware()
         .use(function (obj, next) { assert(obj); next(); })


### PR DESCRIPTION
This PR is a result of a discussion at https://github.com/segmentio/metalsmith/issues/18
I'd like to pass new references to the next middleware. Then you could use convenience methods like `Array.prototype.map` or http://lodash.com/docs#transform to transform the arguments.

It works like this:

``` js
var middleware = ware()
  .use(function (arr, next) {
     next(null, arr.map(function (a) { return a * a; }));
  })
  .use(function (arr, next) {
    console.log(arr);
    next();
  })
  .run([ 1, 2, 3 ]); // 1, 4, 9
```

If a middleware chooses the new method is has to pass the same number of arguments (plus an error argument) to `next`. This is enforced by throwing an Error. I thought that this is not really an application error, so I didn't throw the error inside of the pipeline.
