### PR TITLE
use setImmediate instead of setTimeout for asynchronicity

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,7 @@ Ware.prototype.run = function () {
     fn.apply(null, arr);
   }
 
-  setTimeout(next, 0); // keep it always async
+  setImmediate(next); // keep it always async
+
   return this;
 };


### PR DESCRIPTION
I think using setImmediate instead of setTimeout is more the node way. It is also less cryptic and maybe the most important point, it is faster. On my computer, launching the tests with setTimeout takes 25ms, and only 12ms with setImmediate.
