### PR TITLE
support passing an array of ware instances

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ Ware.prototype.use = function (fn) {
   }
 
   if (fn instanceof Array) {
-    for (var i = 0, f; f = fn[i]; i++) this.fns.push(f);
+    for (var i = 0, f; f = fn[i++];) this.use(f);
     return this;
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,13 @@ describe('ware', function () {
       assert(2 == w.fns.length);
     });
 
+    it('should accept an array of Ware instances', function() {
+      var a = ware().use(noop).use(noop);
+      var b = ware().use(noop).use(noop);
+      var w = ware([a, b]);
+      assert(4 == w.fns.length);
+    })
+
     it('should accept middleware on construct', function () {
       var w = ware(noop);
       assert(1 == w.fns.length);


### PR DESCRIPTION
This allows you to compose ware instances a little easier:

``` js
var ware4 = ware([ware1, ware2, ware3])
```
