### PR TITLE
ignore undefined or false values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ function Ware (fn) {
  */
 
 Ware.prototype.use = function (fn) {
+  if (!fn) return this;
+
   if (fn instanceof Ware) {
     return this.use(fn.fns);
   }

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,11 @@ describe('ware', function () {
       assert(1 == w.fns.length);
     });
 
+    it('should ignore undefined or false values', function() {
+      var w = ware().use(undefined).use(false);
+      assert(0 == w.fns.length);
+    })
+
     it('should accept an array of middleware', function () {
       var w = ware().use([noop, noop]);
       assert(2 == w.fns.length);


### PR DESCRIPTION
This PR allows undefined or false values to be passed in. Nice for when you have optional middleware on plugins/hooks that may or may not be defined. 