### PR TITLE
Support promises in middleware

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,12 @@ Ware.prototype.run = function () {
     } else {
       // sync
       var ret = fn.apply(ctx, args);
-      ret instanceof Error ? next(ret) : next();
+
+      if (promise(ret)) {
+        ret.then(function () { next(); }, done);
+      } else {
+        ret instanceof Error ? next(ret) : next();
+      }
     }
   }
 
@@ -111,6 +116,17 @@ function co(fn) {
   return function() {
     return fn.apply(this, arguments);
   }
+}
+
+/**
+ * Is `value` a promise?
+ *
+ * @param {Mixed} value
+ * @return {Boolean}
+ * @api private
+ */
+function promise(value) {
+  return value && typeof value.then === 'function';
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -181,6 +181,33 @@ describe('ware', function () {
           .use(function (obj) { done(); })
           .run('obj');
       });
+
+      it('should support promises', function (done) {
+        ware()
+          .use(function () {
+            return {
+              then: function (resolve) { resolve(10); }
+            };
+          })
+          .run(done);
+      });
+
+      it('should call error middleware on promise error', function (done) {
+        var errors = 0;
+        ware()
+          .use(function () {
+            return {
+              then: function (resolve, reject) { reject(new Error()); }
+            };
+          })
+          .use(function (next) { errors++; next(err); })
+          .use(function (next) { errors++; next(err); })
+          .run(function (err) {
+            assert(err);
+            assert(0 == errors);
+            done();
+          });
+      });
     })
 
     describe('generator', function() {


### PR DESCRIPTION
Supports synchronous middleware that returns a promise. How should falsy errors be handled? Since falsy values can be used to reject a promise or thrown. Most code doesn't actually handle these cases, so maybe we just do what everyone else does and forward it on or we can switch in a custom error instance when the error is falsy (`next(err || new Error('...')`). 
