### PR TITLE
Feature: throw without callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,16 @@ var wrap = require('wrap-fn');
 module.exports = Ware;
 
 /**
+ * Throw an error.
+ *
+ * @param {Error} error
+ */
+
+function fail (err) {
+  throw err;
+}
+
+/**
  * Initialize a new `Ware` manager, with optional `fns`.
  *
  * @param {Function or Array or Ware} fn (optional)
@@ -64,7 +74,7 @@ Ware.prototype.run = function () {
 
   // next step
   function next (err) {
-    if (err) return done(err);
+    if (err) return (done || fail)(err);
     var fn = fns[i++];
     var arr = slice.call(args);
 

--- a/test/index.js
+++ b/test/index.js
@@ -133,6 +133,15 @@ describe('ware', function () {
           });
       });
 
+      it('should throw an error without callback', function () {
+        var error = new Error();
+        assert.throws(function () {
+          ware()
+            .use(function () { throw error; })
+            .run();
+        });
+      });
+
       it('should receive initial arguments', function (done) {
         ware()
           .use(function (req, res) { return; })


### PR DESCRIPTION
This feature adds better debugging to `Ware#run()` operations without a `done` callback.
Previously, and error was thrown that `done` was not a function, making it hard to debug failing plugins.
With this addition, when operating without `done`, exceptions in plugins are thrown as normal.
